### PR TITLE
Increase NMP reduction when tt move is noisy

### DIFF
--- a/Obsidian/search.cpp
+++ b/Obsidian/search.cpp
@@ -837,7 +837,7 @@ namespace Search {
 
       TT::prefetch(pos.key ^ ZOBRIST_TEMPO);
 
-      int R = std::min((eval - beta) / NmpEvalDiv, (int)NmpEvalDivMin) + depth / NmpDepthDiv + NmpBase;
+      int R = std::min((eval - beta) / NmpEvalDiv, (int)NmpEvalDivMin) + depth / NmpDepthDiv + NmpBase + ttMoveNoisy;
 
       Position newPos = pos;
       playNullMove(newPos, ss);

--- a/Obsidian/types.h
+++ b/Obsidian/types.h
@@ -8,7 +8,7 @@
 #include <nmmintrin.h>
 #include <thread>
 
-const std::string engineVersion = "dev-13.21";
+const std::string engineVersion = "dev-13.22";
 
 using Key = uint64_t;
 using Bitboard = uint64_t;


### PR DESCRIPTION
Elo   | 1.90 +- 1.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 55400 W: 13339 L: 13036 D: 29025
Penta | [120, 6362, 14436, 6659, 123]
https://chess.aronpetkovski.com/test/4552/

bench 2928779