### PR TITLE
Possible speedup

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -242,8 +242,6 @@ void Position::doNullMove() {
 
   sideToMove = them;
   key ^= ZOBRIST_TEMPO;
-
-  checkers = attackersTo(kingSquare(sideToMove), ~sideToMove);
 }
 
 void Position::doMove(Move move, DirtyPieces& dp) {


### PR DESCRIPTION
Note: I did not test (or compile) this

Before null move,
STM cannot be in check, as it is an NMP condition (pos.checkers -> goto moves_loop)
NSTM cannot be in check, otherwise it is an illegal position

Hence checkers will remain at 0 after null move so no new assignments are necessary
